### PR TITLE
Add ability to specify checksum type to file type ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,8 @@ Boolean value to deside if unmanaged files should be purged.
 
 - *Default*: true
 
+checksum
+--------
+The checksum type to use when determining whether to replace a file's contents. Valid values are: 'md5', 'md5lite', 'sha256', 'sha256lite', 'mtime', 'ctime' & 'none'.
+
+- *Default*: md5

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,7 @@ class nrpe_plugins (
   $destination         = undef,
   $purge               = true,
   $force               = true,
+  $checksum            = 'md5',
 ) {
 
   # OS platform defaults
@@ -83,14 +84,25 @@ class nrpe_plugins (
 
   validate_absolute_path($destination)
 
+  # Validate $checksum
+  case $checksum {
+    'md5', 'md5lite', 'sha256', 'sha256lite', 'mtime', 'ctime', 'none': {
+      # noop, these are valid values
+    }
+    default: {
+      fail("Valid values for \$checksum are \'md5\', \'md5lite\', \'sha256\', \'sha256lite\', \'mtime\', \'ctime\' or \'none\'.  Specified value is ${checksum}")
+    }
+  }
+
   file { $destination :
-    ensure  => $nrpe_plugins_ensure,
-    source  => $source,
-    recurse => true,
-    purge   => $purge,
-    force   => $force,
-    owner   => $nrpe_user_real,
-    group   => $nrpe_group_real,
-    require => Package[$nrpe_package_real],
+    ensure   => $nrpe_plugins_ensure,
+    source   => $source,
+    recurse  => true,
+    purge    => $purge,
+    force    => $force,
+    checksum => $checksum,
+    owner    => $nrpe_user_real,
+    group    => $nrpe_group_real,
+    require  => Package[$nrpe_package_real],
   }
 }


### PR DESCRIPTION
Hi! in order to minimize load on the puppet server when comparing many files on many servers, we thought of adding the option to change the default 'md5' checksum.  Let me know what you think.
